### PR TITLE
Events unit tests 

### DIFF
--- a/application/core/pom.xml
+++ b/application/core/pom.xml
@@ -69,6 +69,11 @@
     <artifactId>hibernate-core</artifactId>
     <version>6.6.1.Final</version>
   </dependency>
+    <dependency>
+        <groupId>org.jetbrains</groupId>
+        <artifactId>annotations</artifactId>
+        <version>23.0.0</version>
+    </dependency>
 </dependencies>
 
 <build>

--- a/application/core/src/main/java/com/github/pieter_groenendijk/service/event/emitting/EventEmitter.java
+++ b/application/core/src/main/java/com/github/pieter_groenendijk/service/event/emitting/EventEmitter.java
@@ -1,8 +1,10 @@
 package com.github.pieter_groenendijk.service.event.emitting;
 
 import com.github.pieter_groenendijk.service.event.listener.IEventListener;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
+import java.util.LinkedList;
 
 public abstract class EventEmitter<Context> {
     private final ArrayList<IEventListener<Context>> RUNNABLES;
@@ -11,14 +13,14 @@ public abstract class EventEmitter<Context> {
         RUNNABLES = new ArrayList<>();
     }
 
-    public void attach(IEventListener<Context> runnable) {
+    public void attach(@NotNull IEventListener<Context> runnable) {
         this.RUNNABLES.add(runnable);
     }
 
     /**
      * Relatively unoptimized action. It's not expected that it's called frequently.
      */
-    public void detach(IEventListener<Context> runnable) {
+    public void detach(@NotNull IEventListener<Context> runnable) {
         this.RUNNABLES.remove(runnable);
     }
 

--- a/application/core/src/main/java/com/github/pieter_groenendijk/service/event/emitting/EventEmitterPool.java
+++ b/application/core/src/main/java/com/github/pieter_groenendijk/service/event/emitting/EventEmitterPool.java
@@ -2,6 +2,8 @@ package com.github.pieter_groenendijk.service.event.emitting;
 
 import com.github.pieter_groenendijk.model.event.EventType;
 import com.github.pieter_groenendijk.service.event.listener.IEventListener;
+import jakarta.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.HashMap;
 
@@ -15,7 +17,10 @@ public class EventEmitterPool {
         this.EMITTERS = new HashMap<>();
     }
 
-    public <T> void attach(EventType type, IEventListener<T> runnable) {
+    public <T> void attach(
+        @NotNull EventType type,
+        IEventListener<T> runnable
+    ) {
         EventEmitter<T> emitter = this.get(type);
 
         if (emitter == null) return;
@@ -26,7 +31,10 @@ public class EventEmitterPool {
     /**
      * Relatively unoptimized, only use as last resort.
      */
-    public <T> void detach(EventType type, IEventListener<T> runnable) {
+    public <T> void detach(
+        @NotNull EventType type,
+        IEventListener<T> runnable
+    ) {
         EventEmitter<T> emitter = this.get(type);
 
         if (emitter == null) return;
@@ -37,18 +45,21 @@ public class EventEmitterPool {
     /**
      * Misuse of adding the wrong EventEmitter with the wrong EventType will cause runtime errors!
      */
-    public void add(EventType eventType, EventEmitter<?> eventEmitter) {
+    public void add(
+        @NotNull EventType eventType,
+        EventEmitter<?> eventEmitter
+    ) {
         this.EMITTERS.put(eventType, eventEmitter);
     }
 
-    public void remove(EventType eventType) {
+    public void remove(@NotNull EventType eventType) {
         this.EMITTERS.remove(eventType);
     }
 
     /**
      * Fails silently if the emitter is not found in the pool.
      */
-    public <T> void emit(EventType type, T context) {
+    public <T> void emit(@NotNull EventType type, T context) {
         EventEmitter<T> emitter = this.get(type);
 
         if (emitter == null) return;

--- a/application/core/src/main/java/com/github/pieter_groenendijk/service/event/emitting/EventEmitterPool.java
+++ b/application/core/src/main/java/com/github/pieter_groenendijk/service/event/emitting/EventEmitterPool.java
@@ -19,11 +19,13 @@ public class EventEmitterPool {
 
     public <T> void attach(
         @NotNull EventType type,
-        IEventListener<T> runnable
+        @NotNull IEventListener<T> runnable
     ) {
         EventEmitter<T> emitter = this.get(type);
 
-        if (emitter == null) return;
+        if (emitter == null) {
+            throw new IllegalStateException("EventEmitter for event type " + type + " not found in the pool");
+        }
 
         emitter.attach(runnable);
     }
@@ -33,7 +35,7 @@ public class EventEmitterPool {
      */
     public <T> void detach(
         @NotNull EventType type,
-        IEventListener<T> runnable
+        @NotNull IEventListener<T> runnable
     ) {
         EventEmitter<T> emitter = this.get(type);
 
@@ -47,7 +49,7 @@ public class EventEmitterPool {
      */
     public void add(
         @NotNull EventType eventType,
-        EventEmitter<?> eventEmitter
+        @NotNull EventEmitter<?> eventEmitter
     ) {
         this.EMITTERS.put(eventType, eventEmitter);
     }
@@ -68,7 +70,7 @@ public class EventEmitterPool {
     }
 
     @SuppressWarnings("unchecked") // We assume people haven't mismatched at the .add() method.
-    private <T> EventEmitter<T> get(EventType eventType) {
+    private <T> EventEmitter<T> get(@NotNull EventType eventType) {
         return (EventEmitter<T>) this.EMITTERS.get(eventType);
     }
 }

--- a/application/core/src/main/java/com/github/pieter_groenendijk/service/event/generator/DetachedEventGenerator.java
+++ b/application/core/src/main/java/com/github/pieter_groenendijk/service/event/generator/DetachedEventGenerator.java
@@ -5,6 +5,7 @@ import com.github.pieter_groenendijk.model.event.EventType;
 import com.github.pieter_groenendijk.repository.event.IEventRepository;
 import com.github.pieter_groenendijk.utils.scheduling.longterm.DetachedTask;
 import com.github.pieter_groenendijk.utils.scheduling.TaskStorage;
+import org.jetbrains.annotations.NotNull;
 
 import java.time.LocalDateTime;
 
@@ -23,12 +24,12 @@ public abstract class DetachedEventGenerator<Association, AssociatedEvent extend
 
     private final EventType TYPE;
 
-    protected DetachedEventGenerator(IEventRepository repository, EventType type) {
+    protected DetachedEventGenerator(@NotNull IEventRepository repository, @NotNull EventType type) {
         this.REPOSITORY = repository;
         this.TYPE = type;
     }
 
-    public final DetachedTask<AssociatedEvent> generate(Association association) {
+    public final DetachedTask<AssociatedEvent> generate(@NotNull Association association) {
         AssociatedEvent event = this.generateEvent(association);
 
         return new DetachedTask<>(
@@ -37,7 +38,7 @@ public abstract class DetachedEventGenerator<Association, AssociatedEvent extend
         );
     }
 
-    private AssociatedEvent generateEvent(Association association) {
+    private AssociatedEvent generateEvent(@NotNull Association association) {
         AssociatedEvent event = this.generateEmptyEvent();
 
         event.setScheduledAt(

--- a/application/core/src/main/java/com/github/pieter_groenendijk/service/event/listener/EventListener.java
+++ b/application/core/src/main/java/com/github/pieter_groenendijk/service/event/listener/EventListener.java
@@ -2,15 +2,16 @@ package com.github.pieter_groenendijk.service.event.listener;
 
 import com.github.pieter_groenendijk.model.event.EventType;
 import com.github.pieter_groenendijk.service.event.emitting.EventEmitterPool;
+import org.jetbrains.annotations.NotNull;
 
 public abstract class EventListener<Context> implements IEventListener<Context> {
     private final EventType TYPE;
 
-    protected EventListener(EventType type) {
+    protected EventListener(@NotNull EventType type) {
         this.TYPE = type;
     }
 
-    public final void attachTo(EventEmitterPool pool) {
+    public final void attachTo(@NotNull EventEmitterPool pool) {
         pool.attach(this.TYPE, this);
     }
 
@@ -25,7 +26,7 @@ public abstract class EventListener<Context> implements IEventListener<Context> 
 
     protected abstract void tryReact(Context context) throws Exception;
 
-    protected void handleReactException(Exception exception) {
+    protected void handleReactException(@NotNull Exception exception) {
         // TODO: Logging
     }
 }

--- a/application/core/src/main/java/com/github/pieter_groenendijk/service/event/scheduling/EventScheduler.java
+++ b/application/core/src/main/java/com/github/pieter_groenendijk/service/event/scheduling/EventScheduler.java
@@ -6,6 +6,7 @@ import com.github.pieter_groenendijk.repository.scheduling.ITaskRepository;
 import com.github.pieter_groenendijk.service.event.emitting.EventEmitterPool;
 import com.github.pieter_groenendijk.utils.scheduling.longterm.LongTermTaskScheduler;
 import com.github.pieter_groenendijk.utils.scheduling.TaskScheduler;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
 
@@ -14,9 +15,9 @@ public class EventScheduler extends LongTermTaskScheduler<Event<?>> {
     private final EventEmitterPool EMITTER_POOL;
 
     public EventScheduler(
-        ITaskRepository<Event<?>> taskRepository,
-        TaskScheduler scheduler,
-        EventEmitterPool eventEmitterPool
+        @NotNull ITaskRepository<Event<?>> taskRepository,
+        @NotNull TaskScheduler scheduler,
+        @NotNull EventEmitterPool eventEmitterPool
     ) {
         super(
             taskRepository,
@@ -28,8 +29,8 @@ public class EventScheduler extends LongTermTaskScheduler<Event<?>> {
 
     public EventScheduler(
         int amountOfThreads,
-        ITaskRepository<Event<?>> taskRepository,
-        EventEmitterPool eventEmitterPool
+        @NotNull ITaskRepository<Event<?>> taskRepository,
+        @NotNull EventEmitterPool eventEmitterPool
     ) {
         super(
             taskRepository,
@@ -40,7 +41,7 @@ public class EventScheduler extends LongTermTaskScheduler<Event<?>> {
     }
 
     @Override
-    protected void executeTask(Event<?> event) {
+    protected void executeTask(@NotNull Event<?> event) {
         this.EMITTER_POOL.emit(
             event.getType(),
             event.getAssociation()

--- a/application/core/src/main/java/com/github/pieter_groenendijk/utils/scheduling/longterm/DetachedTask.java
+++ b/application/core/src/main/java/com/github/pieter_groenendijk/utils/scheduling/longterm/DetachedTask.java
@@ -24,4 +24,12 @@ public class DetachedTask<T extends Task> {
             this.TASK
         );
     }
+
+    public T getTask() {
+        return TASK;
+    }
+
+    public TaskStorage<T> getStorage() {
+        return STORAGE;
+    }
 }

--- a/application/core/src/test/java/com/github/pieter_groenendijk/service/event/emitting/EventEmitterPoolTest.java
+++ b/application/core/src/test/java/com/github/pieter_groenendijk/service/event/emitting/EventEmitterPoolTest.java
@@ -1,0 +1,129 @@
+package com.github.pieter_groenendijk.service.event.emitting;
+
+import com.github.pieter_groenendijk.model.event.EventType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.verification.VerificationMode;
+
+import static org.mockito.Mockito.*;
+
+public class EventEmitterPoolTest {
+    private EventEmitterPool pool;
+
+    @BeforeEach
+    void beforeEach() {
+        pool = new EventEmitterPool();
+    }
+
+    @Test
+    void testEmit_emittedForExistingEventType() {
+        EventEmitter<String> emitter = mock(EventEmitter.class);
+        EventType type = EventType.ALMOST_OVERDUE_LOAN;
+        String context = "example";
+
+        this.pool.add(type, emitter);
+
+        this.pool.emit(type, context);
+
+        verify(emitter).emit(context);
+    }
+
+    @Test
+    void testEmit_notEmittedForNonExistingEventType() {
+        EventEmitter<String> emitter = mock(EventEmitter.class);
+        EventType type = EventType.ALMOST_OVERDUE_LOAN;
+        String context = "example";
+
+        this.pool.emit(type, context);
+
+        verifyNoInteractions(emitter);
+    }
+
+    @Test
+    void testEmit_multipleAdded() {
+        EventEmitter<String> stringEmitter = mock(EventEmitter.class);
+        EventEmitter<Long> longEmitter = mock(EventEmitter.class);
+
+        EventEmitter<Character> usedEmitter = mock(EventEmitter.class);
+        EventType usedType = EventType.UNCOLLECTED_RESERVATION_EVENT;
+        Character usedContext = Character.valueOf('k');
+
+        this.pool.add(EventType.OVERDUE_LOAN, stringEmitter);
+        this.pool.add(usedType, usedEmitter);
+        this.pool.add(EventType.ALMOST_OVERDUE_LOAN, longEmitter);
+
+        this.pool.emit(usedType, usedContext);
+
+        verify(usedEmitter).emit(usedContext);
+        verifyNoInteractions(
+            stringEmitter,
+            longEmitter
+        );
+    }
+
+    @Test
+    void testEmit_multipleAdded_multipleEmitted() {
+        EventEmitter<Long> longEmitter = mock(EventEmitter.class);
+
+        EventEmitter<Character> firstUsedEmitter = mock(EventEmitter.class);
+        EventType firstUsedType = EventType.UNCOLLECTED_RESERVATION_EVENT;
+        Character firstUsedContext = Character.valueOf('k');
+
+        EventEmitter<String> secondUsedEmitter = mock(EventEmitter.class);
+        EventType secondUsedType = EventType.ALMOST_OVERDUE_LOAN;
+        String secondUsedContext = "exampleeeee";
+
+        this.pool.add(EventType.OVERDUE_LOAN, secondUsedEmitter);
+        this.pool.add(firstUsedType, firstUsedEmitter);
+        this.pool.add(secondUsedType, secondUsedEmitter);
+
+        // First emit
+        this.pool.emit(firstUsedType, firstUsedContext);
+
+        verify(firstUsedEmitter).emit(firstUsedContext);
+        verifyNoInteractions(
+            secondUsedEmitter,
+            longEmitter
+        );
+
+        // Second emit
+        this.pool.emit(secondUsedType, secondUsedContext);
+
+        verifyNoMoreInteractions(
+            firstUsedEmitter,
+            longEmitter
+        );
+        verify(secondUsedEmitter).emit(secondUsedContext);
+    }
+
+    @Test
+    void testEmit_overwrittenEmitter() {
+        EventEmitter<String> stringEmitter = mock(EventEmitter.class);
+
+        EventEmitter<String> usedEmitter = mock(EventEmitter.class);
+        EventType usedType = EventType.UNCOLLECTED_RESERVATION_EVENT;
+        String usedContext = "example";
+
+        this.pool.add(usedType, stringEmitter);
+        this.pool.add(usedType, usedEmitter);
+
+        this.pool.emit(usedType, usedContext);
+
+        verifyNoInteractions(stringEmitter);
+        verify(usedEmitter).emit(usedContext);
+    }
+
+    @Test
+    void testEmit_emitterIsRemoved() {
+        EventEmitter<String> emitter = mock(EventEmitter.class);
+        EventType type = EventType.ALMOST_OVERDUE_LOAN;
+        String context = "example";
+
+        this.pool.add(type, emitter);
+        this.pool.remove(type);
+
+        this.pool.emit(type, context);
+
+        verifyNoInteractions(emitter);
+    }
+}

--- a/application/core/src/test/java/com/github/pieter_groenendijk/service/event/emitting/EventEmitterPoolTest.java
+++ b/application/core/src/test/java/com/github/pieter_groenendijk/service/event/emitting/EventEmitterPoolTest.java
@@ -347,4 +347,24 @@ public class EventEmitterPoolTest {
         verify(emitter, times(1)).detach(listener);
         verify(secondEmitter, times(0)).detach(secondListener);
     }
+
+    @Test
+    void testRemove_existingEmitter() {
+        EventEmitter<String> emitter = mock(EventEmitter.class);
+        EventType type = EventType.ALMOST_OVERDUE_LOAN;
+        String context = "exmaple";
+
+        this.pool.add(type, emitter);
+        this.pool.remove(type);
+
+        this.pool.emit(type, context);
+
+        verifyNoInteractions(emitter);
+    }
+
+    @Test
+    void testRemove_nonExistentEmitter() {
+        this.pool.remove(EventType.ALMOST_OVERDUE_LOAN);
+    }
 }
+

--- a/application/core/src/test/java/com/github/pieter_groenendijk/service/event/emitting/EventEmitterPoolTest.java
+++ b/application/core/src/test/java/com/github/pieter_groenendijk/service/event/emitting/EventEmitterPoolTest.java
@@ -1,10 +1,11 @@
 package com.github.pieter_groenendijk.service.event.emitting;
 
 import com.github.pieter_groenendijk.model.event.EventType;
+import com.github.pieter_groenendijk.service.event.listener.IEventListener;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.verification.VerificationMode;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 
 public class EventEmitterPoolTest {
@@ -25,7 +26,7 @@ public class EventEmitterPoolTest {
 
         this.pool.emit(type, context);
 
-        verify(emitter).emit(context);
+        verify(emitter, times(1)).emit(context);
     }
 
     @Test
@@ -54,7 +55,7 @@ public class EventEmitterPoolTest {
 
         this.pool.emit(usedType, usedContext);
 
-        verify(usedEmitter).emit(usedContext);
+        verify(usedEmitter, times(1)).emit(usedContext);
         verifyNoInteractions(
             stringEmitter,
             longEmitter
@@ -80,7 +81,7 @@ public class EventEmitterPoolTest {
         // First emit
         this.pool.emit(firstUsedType, firstUsedContext);
 
-        verify(firstUsedEmitter).emit(firstUsedContext);
+        verify(firstUsedEmitter, times(1)).emit(firstUsedContext);
         verifyNoInteractions(
             secondUsedEmitter,
             longEmitter
@@ -93,7 +94,7 @@ public class EventEmitterPoolTest {
             firstUsedEmitter,
             longEmitter
         );
-        verify(secondUsedEmitter).emit(secondUsedContext);
+        verify(secondUsedEmitter, times(1)).emit(secondUsedContext);
     }
 
     @Test
@@ -110,7 +111,7 @@ public class EventEmitterPoolTest {
         this.pool.emit(usedType, usedContext);
 
         verifyNoInteractions(stringEmitter);
-        verify(usedEmitter).emit(usedContext);
+        verify(usedEmitter, times(1)).emit(usedContext);
     }
 
     @Test
@@ -125,5 +126,109 @@ public class EventEmitterPoolTest {
         this.pool.emit(type, context);
 
         verifyNoInteractions(emitter);
+    }
+
+
+    @Test
+    void testAttach_existingEmitter() {
+        EventEmitter<String> emitter = mock(EventEmitter.class);
+        EventType type = EventType.ALMOST_OVERDUE_LOAN;
+        IEventListener<String> listener = (context) -> {};
+
+        this.pool.add(type, emitter);
+
+        this.pool.attach(type, listener);
+
+        verify(emitter, times(1)).attach(listener);
+    }
+
+    @Test
+    void testAttach_nonExistingEmitter() {
+        EventType type = EventType.ALMOST_OVERDUE_LOAN;
+        IEventListener<String> listener = (context) -> {};
+
+        assertThrows(
+            IllegalStateException.class,
+            () -> this.pool.attach(type, listener)
+        );
+    }
+
+    @Test
+    void testAttach_multipleOfSameTypeAndDifferentListener() {
+        EventEmitter<String> emitter = mock(EventEmitter.class);
+        EventType type = EventType.ALMOST_OVERDUE_LOAN;
+        IEventListener<String> firstListener = (context) -> {};
+        IEventListener<String> secondListener = (context) -> {};
+        IEventListener<String> thirdListener = (context) -> {};
+
+        this.pool.add(type, emitter);
+
+        this.pool.attach(type, firstListener);
+        this.pool.attach(type, secondListener);
+        this.pool.attach(type, thirdListener);
+
+        verify(emitter, times(1)).attach(firstListener);
+        verify(emitter, times(1)).attach(secondListener);
+        verify(emitter, times(1)).attach(thirdListener);
+    }
+
+    @Test
+    void testAttach_multipleOfSameTypeAndSameListener() {
+        EventEmitter<String> emitter = mock(EventEmitter.class);
+        EventType type = EventType.ALMOST_OVERDUE_LOAN;
+        IEventListener<String> firstListener = (context) -> {};
+
+        this.pool.add(type, emitter);
+
+        this.pool.attach(type, firstListener);
+        this.pool.attach(type, firstListener);
+        this.pool.attach(type, firstListener);
+
+        verify(emitter, times(3)).attach(firstListener);
+    }
+
+    @Test
+    void testAttach_multipleOfDifferentTypeAndDifferentListener() {
+        EventEmitter<String> emitter = mock(EventEmitter.class);
+        EventEmitter<Long> secondEmitter = mock(EventEmitter.class);
+
+        EventType type = EventType.ALMOST_OVERDUE_LOAN;
+        EventType secondType = EventType.DAY_OVERDUE_LOAN;
+
+        IEventListener<String> firstListener = (context) -> {};
+        IEventListener<Long> secondListener = (context) -> {};
+
+        this.pool.add(type, emitter);
+        this.pool.add(secondType, secondEmitter);
+        this.pool.add(type, emitter);
+
+        this.pool.attach(type, firstListener);
+        this.pool.attach(secondType, secondListener);
+        this.pool.attach(type, firstListener);
+
+        verify(emitter, times(2)).attach(firstListener);
+        verify(secondEmitter, times(1)).attach(secondListener);
+    }
+
+    @Test
+    void testAttach_multipleOfDifferentTypeAndSameListener() {
+        EventEmitter<String> emitter = mock(EventEmitter.class);
+        EventEmitter<String> secondEmitter = mock(EventEmitter.class);
+
+        EventType type = EventType.ALMOST_OVERDUE_LOAN;
+        EventType secondType = EventType.DAY_OVERDUE_LOAN;
+
+        IEventListener<String> firstListener = (context) -> {};
+
+        this.pool.add(type, emitter);
+        this.pool.add(secondType, secondEmitter);
+        this.pool.add(type, emitter);
+
+        this.pool.attach(type, firstListener);
+        this.pool.attach(secondType, firstListener);
+        this.pool.attach(type, firstListener);
+
+        verify(emitter, times(2)).attach(firstListener);
+        verify(secondEmitter, times(1)).attach(firstListener);
     }
 }

--- a/application/core/src/test/java/com/github/pieter_groenendijk/service/event/emitting/EventEmitterPoolTest.java
+++ b/application/core/src/test/java/com/github/pieter_groenendijk/service/event/emitting/EventEmitterPoolTest.java
@@ -231,4 +231,120 @@ public class EventEmitterPoolTest {
         verify(emitter, times(2)).attach(firstListener);
         verify(secondEmitter, times(1)).attach(firstListener);
     }
+
+
+    @Test
+    void testDetach_existingListener() {
+        EventEmitter<String> emitter = mock(EventEmitter.class);
+        EventType type = EventType.ALMOST_OVERDUE_LOAN;
+        IEventListener<String> listener = (context) -> {};
+
+        this.pool.add(type, emitter);
+        this.pool.attach(type, listener);
+
+        this.pool.detach(type, listener);
+
+        verify(emitter, times(1)).detach(listener);
+    }
+
+    @Test
+    void testDetach_nonExistentEmitter() {
+        EventEmitter<String> emitter = mock(EventEmitter.class);
+        EventType type = EventType.ALMOST_OVERDUE_LOAN;
+        IEventListener<String> listener = (context) -> {};
+
+        this.pool.detach(type, listener);
+
+        verifyNoInteractions(emitter);
+    }
+
+    @Test
+    void testDetach_nonExistentListener() {
+        EventEmitter<String> emitter = mock(EventEmitter.class);
+        EventType type = EventType.ALMOST_OVERDUE_LOAN;
+        IEventListener<String> listener = (context) -> {};
+
+        this.pool.add(type, emitter);
+
+        this.pool.detach(type, listener);
+
+        verify(emitter, times(1)).detach(listener);
+    }
+
+    @Test
+    void testDetach_multipleDifferentListeners() {
+        EventEmitter<String> emitter = mock(EventEmitter.class);
+        EventType type = EventType.ALMOST_OVERDUE_LOAN;
+        IEventListener<String> listener = (context) -> {};
+        IEventListener<String> secondListener = (context) -> {};
+
+        this.pool.add(type, emitter);
+        this.pool.attach(type, listener);
+        this.pool.attach(type, secondListener);
+
+        this.pool.detach(type, listener);
+
+        verify(emitter, times(1)).detach(listener);
+        verify(emitter, times(0)).detach(secondListener);
+    }
+
+    @Test
+    void testDetach_multipleSameListeners() {
+        EventEmitter<String> emitter = mock(EventEmitter.class);
+        EventType type = EventType.ALMOST_OVERDUE_LOAN;
+        IEventListener<String> listener = (context) -> {};
+
+        this.pool.add(type, emitter);
+        this.pool.attach(type, listener);
+        this.pool.attach(type, listener);
+
+        this.pool.detach(type, listener);
+
+        verify(emitter, times(1)).detach(listener);
+    }
+
+    @Test
+    void testDetach_multipleEmittersSameListeners() {
+        EventEmitter<String> emitter = mock(EventEmitter.class);
+        EventType type = EventType.ALMOST_OVERDUE_LOAN;
+
+        EventEmitter<String> secondEmitter = mock(EventEmitter.class);
+        EventType secondType = EventType.DAY_OVERDUE_LOAN;
+
+        IEventListener<String> listener = (context) -> {};
+
+        this.pool.add(type, emitter);
+        this.pool.add(secondType, secondEmitter);
+
+        this.pool.attach(type, listener);
+        this.pool.attach(secondType, listener);
+
+        this.pool.detach(type, listener);
+
+        verify(emitter, times(1)).detach(listener);
+        verify(secondEmitter, times(0)).detach(listener);
+    }
+
+    @Test
+    void testDetach_multipleEmittersDifferentListeners() {
+        EventEmitter<String> emitter = mock(EventEmitter.class);
+        EventType type = EventType.ALMOST_OVERDUE_LOAN;
+        IEventListener<String> listener = (context) -> {};
+
+        EventEmitter<String> secondEmitter = mock(EventEmitter.class);
+        EventType secondType = EventType.DAY_OVERDUE_LOAN;
+        IEventListener<String> secondListener = (context) -> {};
+
+
+        this.pool.add(type, emitter);
+        this.pool.add(secondType, secondEmitter);
+
+        this.pool.attach(type, listener);
+        this.pool.attach(secondType, secondListener);
+
+        this.pool.detach(type, listener);
+
+        verify(emitter, times(1)).detach(listener);
+        verify(secondEmitter, times(0)).detach(secondListener);
+    }
 }

--- a/application/core/src/test/java/com/github/pieter_groenendijk/service/event/emitting/EventEmitterTest.java
+++ b/application/core/src/test/java/com/github/pieter_groenendijk/service/event/emitting/EventEmitterTest.java
@@ -1,4 +1,140 @@
 package com.github.pieter_groenendijk.service.event.emitting;
 
+import com.github.pieter_groenendijk.repository.event.IEventRepository;
+import com.github.pieter_groenendijk.service.event.listener.IEventListener;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.mockito.Mockito.*;
+
 public class EventEmitterTest {
+    private EventEmitter<String> emitter;
+
+    private IEventListener<String> listener;
+    private String context;
+
+    @BeforeEach
+    void beforeEach() {
+        this.emitter = new EventEmitter<>() {
+        };
+        this.listener = mock(IEventListener.class);
+        this.context = "example";
+    }
+
+    @Test
+    void testEmit() {
+        this.emitter.emit(this.context);
+    }
+
+    @Test
+    void testDetach() {
+        this.emitter.detach(this.listener);
+    }
+
+    @Test
+    void testAttach() {
+        this.emitter.attach(listener);
+    }
+
+
+    @Test
+    void testEmit_afterSingleAttached() {
+        this.emitter.attach(listener);
+
+        this.emitter.emit(this.context);
+
+        verify(listener, times(1)).react(this.context);
+    }
+
+    @Test
+    void testEmit_afterMultipleDifferentAttached() {
+        IEventListener<String> secondListener = mock(IEventListener.class);
+        IEventListener<String> thirdListener = mock(IEventListener.class);
+
+        this.emitter.attach(this.listener);
+        this.emitter.attach(secondListener);
+        this.emitter.attach(thirdListener);
+
+        this.emitter.emit(this.context);
+
+        verify(this.listener, times(1)).react(this.context);
+        verify(secondListener, times(1)).react(this.context);
+    }
+
+    @Test
+    void testEmit_afterMultipleSameAttached() {
+        this.emitter.attach(this.listener);
+        this.emitter.attach(this.listener);
+        this.emitter.attach(this.listener);
+        this.emitter.attach(this.listener);
+
+        this.emitter.emit(this.context);
+
+        verify(this.listener, times(4)).react(this.context);
+    }
+
+    @Test
+    void testEmit_afterSingleDetached() {
+        this.emitter.attach(this.listener);
+
+        this.emitter.detach(this.listener);
+
+        this.emitter.emit(this.context);
+
+        verifyNoInteractions(this.listener);
+    }
+
+    @Test
+    void testEmit_afterSingleDetachedOfMultipleDifferent() {
+        IEventListener<String> secondListener = mock(IEventListener.class);
+        IEventListener<String> thirdListener = mock(IEventListener.class);
+
+        this.emitter.attach(this.listener);
+        this.emitter.attach(secondListener);
+        this.emitter.attach(thirdListener);
+
+        this.emitter.detach(secondListener);
+
+        this.emitter.emit(this.context);
+
+        verifyNoInteractions(secondListener);
+        verify(this.listener, times(1)).react(this.context);
+        verify(thirdListener, times(1)).react(this.context);
+    }
+
+    @Test
+    void testEmit_afterSingleDetachedOfMultipleSame() {
+        this.emitter.attach(this.listener);
+        this.emitter.attach(this.listener);
+        this.emitter.attach(this.listener);
+
+        this.emitter.detach(this.listener);
+
+        this.emitter.emit(this.context);
+
+        verify(this.listener, times(2)).react(context);
+    }
+
+    @Test
+    void testEmit_afterMultipleDetachedOfMultiple() {
+        IEventListener<String> secondListener = mock(IEventListener.class);
+        IEventListener<String> thirdListener = mock(IEventListener.class);
+
+        this.emitter.attach(this.listener);
+        this.emitter.attach(this.listener);
+        this.emitter.attach(secondListener);
+        this.emitter.attach(this.listener);
+        this.emitter.attach(thirdListener);
+        this.emitter.attach(thirdListener);
+
+        this.emitter.detach(this.listener);
+        this.emitter.detach(secondListener);
+        this.emitter.detach(thirdListener);
+
+        this.emitter.emit(this.context);
+
+        verify(this.listener, times(2)).react(this.context);
+        verify(secondListener, times(0)).react(this.context);
+        verify(thirdListener, times(1)).react(this.context);
+    }
 }

--- a/application/core/src/test/java/com/github/pieter_groenendijk/service/event/emitting/EventEmitterTest.java
+++ b/application/core/src/test/java/com/github/pieter_groenendijk/service/event/emitting/EventEmitterTest.java
@@ -1,6 +1,5 @@
 package com.github.pieter_groenendijk.service.event.emitting;
 
-import com.github.pieter_groenendijk.repository.event.IEventRepository;
 import com.github.pieter_groenendijk.service.event.listener.IEventListener;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/application/core/src/test/java/com/github/pieter_groenendijk/service/event/emitting/EventEmitterTest.java
+++ b/application/core/src/test/java/com/github/pieter_groenendijk/service/event/emitting/EventEmitterTest.java
@@ -1,0 +1,4 @@
+package com.github.pieter_groenendijk.service.event.emitting;
+
+public class EventEmitterTest {
+}

--- a/application/core/src/test/java/com/github/pieter_groenendijk/service/event/generator/DetachedEventGeneratorTest.java
+++ b/application/core/src/test/java/com/github/pieter_groenendijk/service/event/generator/DetachedEventGeneratorTest.java
@@ -9,15 +9,12 @@ import com.github.pieter_groenendijk.utils.scheduling.TaskStorage;
 import com.github.pieter_groenendijk.utils.scheduling.longterm.DetachedTask;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 
 import java.time.LocalDateTime;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 import static org.mockito.MockitoAnnotations.openMocks;
 
 public class DetachedEventGeneratorTest {

--- a/application/core/src/test/java/com/github/pieter_groenendijk/service/event/generator/DetachedEventGeneratorTest.java
+++ b/application/core/src/test/java/com/github/pieter_groenendijk/service/event/generator/DetachedEventGeneratorTest.java
@@ -1,0 +1,146 @@
+package com.github.pieter_groenendijk.service.event.generator;
+
+import com.github.pieter_groenendijk.model.Loan;
+import com.github.pieter_groenendijk.model.event.Event;
+import com.github.pieter_groenendijk.model.event.EventType;
+import com.github.pieter_groenendijk.model.event.LoanEvent;
+import com.github.pieter_groenendijk.repository.event.IEventRepository;
+import com.github.pieter_groenendijk.utils.scheduling.TaskStorage;
+import com.github.pieter_groenendijk.utils.scheduling.longterm.DetachedTask;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+
+import java.time.LocalDateTime;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.MockitoAnnotations.openMocks;
+
+public class DetachedEventGeneratorTest {
+    @Mock
+    private IEventRepository repository;
+
+    private DetachedEventGenerator<Loan, LoanEvent> generator;
+
+    private abstract class MockDetachedEventGenerator<Association, AssociatedEvent extends Event<Association>> extends DetachedEventGenerator<Association, AssociatedEvent> {
+        protected MockDetachedEventGenerator(EventType type) {
+            super(
+                repository,
+                type
+            );
+        }
+
+        @Override
+        protected abstract AssociatedEvent generateEmptyEvent();
+
+        @Override
+        protected LocalDateTime determineScheduledDateTime(Association assocation) {
+            return LocalDateTime.now();
+        }
+
+        @Override
+        protected TaskStorage<AssociatedEvent> generateEventStorage() {
+            return (loanEvent) -> {
+
+            };
+        }
+    }
+
+    @BeforeEach
+    void beforeEach() {
+        openMocks(this);
+    }
+
+    @Test
+    void testGenerate() {
+        this.generator = new MockDetachedEventGenerator<Loan, LoanEvent>(EventType.ALMOST_OVERDUE_LOAN) {
+            @Override
+            protected LoanEvent generateEmptyEvent() {
+                return mock(LoanEvent.class);
+            }
+        };
+
+        this.generator.generate(mock(Loan.class));
+    }
+
+    @Test
+    void testGenerate_returnsTask() {
+        this.generator = new MockDetachedEventGenerator<Loan, LoanEvent>(EventType.ALMOST_OVERDUE_LOAN) {
+            @Override
+            protected LoanEvent generateEmptyEvent() {
+                return mock(LoanEvent.class);
+            }
+        };
+
+        DetachedTask<LoanEvent> task = this.generator.generate(mock(Loan.class));
+
+        assertNotNull(task);
+    }
+
+    @Test
+    void testGenerate_correctScheduledDateTime() {
+        LoanEvent returnedLoanEvent = new LoanEvent();
+
+        LocalDateTime returnedScheduledDateTime = LocalDateTime.now();
+
+        this.generator = new MockDetachedEventGenerator<Loan, LoanEvent>(EventType.ALMOST_OVERDUE_LOAN) {
+            @Override
+            protected LoanEvent generateEmptyEvent() {
+                return returnedLoanEvent;
+            }
+
+            @Override
+            protected LocalDateTime determineScheduledDateTime(Loan loan) {
+                return returnedScheduledDateTime;
+            }
+        };
+
+        this.generator.generate(mock(Loan.class));
+
+        assertEquals(returnedScheduledDateTime, returnedLoanEvent.getScheduledAt());
+    }
+
+    @Test
+    void testGenerate_correctEventType() {
+        LoanEvent returnedLoanEvent = new LoanEvent();
+
+        EventType eventType = EventType.ALMOST_OVERDUE_LOAN;
+
+        this.generator = new MockDetachedEventGenerator<Loan, LoanEvent>(eventType) {
+            @Override
+            protected LoanEvent generateEmptyEvent() {
+                return returnedLoanEvent;
+            }
+        };
+
+        this.generator.generate(mock(Loan.class));
+
+        assertEquals(eventType, returnedLoanEvent.getType());
+    }
+
+    @Test
+    void testGenerate_correctAssociation() {
+        LoanEvent returnedLoanEvent = new LoanEvent();
+
+        this.generator = new MockDetachedEventGenerator<Loan, LoanEvent>(EventType.ALMOST_OVERDUE_LOAN) {
+            @Override
+            protected LoanEvent generateEmptyEvent() {
+                return returnedLoanEvent;
+            }
+        };
+
+        Loan association = mock(Loan.class);
+
+        this.generator.generate(association);
+
+        assertEquals(association, returnedLoanEvent.getAssociation());
+    }
+
+    // TODO: How to correctly test?
+    @Test
+    void testGenerate_correctStorage() {}
+}

--- a/application/core/src/test/java/com/github/pieter_groenendijk/service/event/listener/EventListenerTest.java
+++ b/application/core/src/test/java/com/github/pieter_groenendijk/service/event/listener/EventListenerTest.java
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.openMocks;
 

--- a/application/core/src/test/java/com/github/pieter_groenendijk/service/event/listener/EventListenerTest.java
+++ b/application/core/src/test/java/com/github/pieter_groenendijk/service/event/listener/EventListenerTest.java
@@ -1,0 +1,92 @@
+package com.github.pieter_groenendijk.service.event.listener;
+
+import com.github.pieter_groenendijk.model.event.EventType;
+import com.github.pieter_groenendijk.service.event.emitting.EventEmitterPool;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+import static org.mockito.MockitoAnnotations.openMocks;
+
+public class EventListenerTest {
+    @Mock
+    private EventType eventType;
+
+    private EventListener<Long> eventListener;
+
+    @BeforeEach
+    void beforeEach() {
+        openMocks(this);
+    }
+
+    @Test
+    void testAttachTo() {
+        this.eventListener = new EventListener<Long>(mock(EventType.class)) {
+            @Override
+            protected void tryReact(Long aLong) throws Exception {}
+        };
+
+        this.eventListener.attachTo(mock(EventEmitterPool.class));
+    }
+
+    @Test
+    void testAttachTo_attached() {
+        EventType type = mock(EventType.class);
+        EventEmitterPool emitterPool = mock(EventEmitterPool.class);
+        this.eventListener = new EventListener<Long>(type) {
+            @Override
+            protected void tryReact(Long aLong) throws Exception {}
+        };
+
+        this.eventListener.attachTo(emitterPool);
+
+        verify(emitterPool, times(1)).attach(type, this.eventListener);
+    }
+
+    @Test
+    void testReact() {
+        this.eventListener = new EventListener<Long>(mock(EventType.class)) {
+            @Override
+            protected void tryReact(Long aLong) throws Exception {}
+        };
+
+        this.eventListener.react(123L);
+    }
+
+    @Test
+    void testReact_tryReactCalled() throws Exception {
+        Long context = 1L;
+
+        this.eventListener = spy(
+            new EventListener<Long>(mock(EventType.class)) {
+                @Override
+                protected void tryReact(Long aLong) {}
+            }
+        );
+
+        this.eventListener.react(context);
+
+        verify(this.eventListener, times(1)).tryReact(context);
+    }
+
+    @Test
+    void testReact_tryReactWithException() {
+        Exception thrownException = new Exception();
+
+        this.eventListener = spy(
+            new EventListener<Long>(mock(EventType.class)) {
+                @Override
+                protected void tryReact(Long aLong) throws Exception {
+                    throw thrownException;
+                }
+            }
+        );
+
+        this.eventListener.react(1213123L);
+
+        // TODO: We should check the actual logging in the future. Testing results of implementation, not the implementation self.
+        verify(this.eventListener, times(1)).handleReactException(thrownException);
+    }
+}

--- a/application/core/src/test/java/com/github/pieter_groenendijk/service/event/scheduling/EventSchedulerTest.java
+++ b/application/core/src/test/java/com/github/pieter_groenendijk/service/event/scheduling/EventSchedulerTest.java
@@ -1,0 +1,73 @@
+package com.github.pieter_groenendijk.service.event.scheduling;
+
+import com.github.pieter_groenendijk.model.event.Event;
+import com.github.pieter_groenendijk.model.event.EventType;
+import com.github.pieter_groenendijk.repository.scheduling.ITaskRepository;
+import com.github.pieter_groenendijk.service.event.emitting.EventEmitterPool;
+import com.github.pieter_groenendijk.utils.scheduling.TaskScheduler;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+import javax.swing.event.HyperlinkEvent;
+
+import static org.mockito.Mockito.*;
+import static org.mockito.MockitoAnnotations.openMocks;
+
+public class EventSchedulerTest {
+    @Mock
+    private ITaskRepository<Event<?>> taskRepository;
+    @Mock
+    private EventEmitterPool emitterPool;
+    @Mock
+    private TaskScheduler taskScheduler;
+
+
+    private EventScheduler eventScheduler;
+
+    @BeforeEach
+    void beforeEach() {
+        openMocks(this);
+
+        this.eventScheduler = new EventScheduler(
+            taskRepository,
+            taskScheduler,
+            emitterPool
+        );
+    }
+
+    @Test
+    void testExecuteTask() {
+        this.eventScheduler.executeTask(mock(Event.class));
+    }
+
+    // TODO: Very integration specific, something we would want to prevent mostly.
+    @Test
+    void testExecuteTask_emitInPool() {
+        EventType eventType = mock(EventType.class);
+        String association = "example";
+
+        Event<String> event = mock(Event.class);
+        when(event.getAssociation()).thenReturn(association);
+        when(event.getType()).thenReturn(eventType);
+
+        this.eventScheduler.executeTask(event);
+
+        verify(this.emitterPool, times(1)).emit(eventType, association);
+    }
+
+    @Test
+    void testExecuteTask_multipleCalled() {
+        EventType eventType = mock(EventType.class);
+        String association = "example";
+
+        Event<String> event = mock(Event.class);
+        when(event.getAssociation()).thenReturn(association);
+        when(event.getType()).thenReturn(eventType);
+
+        this.eventScheduler.executeTask(event);
+        this.eventScheduler.executeTask(event);
+
+        verify(this.emitterPool, times(2)).emit(eventType, association);
+    }
+}


### PR DESCRIPTION
Also added an annotation library that doesn't really do something at runtime, but is just handy to show for example that a parameter never should be null. This way I can get away with not having null checks for certain things.